### PR TITLE
fix: fix RecordNotFound error by overriding form action of blog editing page

### DIFF
--- a/app/controllers/admin/blogs_controller.rb
+++ b/app/controllers/admin/blogs_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class BlogsController < Fae::BaseController
+    before_action :form_url, only: %i[new edit]
 
     def index
       @items = Blog.order('date_of_news DESC')
@@ -14,6 +15,10 @@ module Admin
 
     def build_assets
       @item.build_cover_image if @item.cover_image.blank?
+    end
+
+    def form_url
+      @form_url = action_name == 'new' ? admin_blogs_path : admin_blog_path(@item.id)
     end
   end
 end

--- a/app/views/admin/blogs/_form.html.slim
+++ b/app/views/admin/blogs/_form.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for([:admin, @item]) do |f|
+= simple_form_for([:admin, @item], url: @form_url) do |f|
   header.content-header.js-content-header
     == render 'fae/shared/form_header', header: @klass_name
   == render 'fae/shared/errors'


### PR DESCRIPTION
Fae CMS doesn't support customizing item identifier, it uses record's ID column for all internal communication, for example: https://github.com/wearefine/fae/blob/v2.1.0/app/controllers/fae/base_controller.rb#L92-L94

This PR override the form action for blog model instead of monkey patching fae gem.

close #9